### PR TITLE
Fix margin-bottom got override by homeSubtitlePrinter

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -916,7 +916,7 @@ a.footnote-ref {
     overflow: hidden; /* Ensures the content is not revealed until the animation */
     border-right: .5em solid $typewriter; /* The typwriter cursor */
     white-space: nowrap; /* Keeps the content on a single line */
-    margin: 0 auto; /* Gives that scrolling effect as the typing happens */
+    margin: 0 auto 1.5em auto; /* Gives that scrolling effect as the typing happens */
     // letter-spacing: .100em; /* Adjust as needed */
       animation: typing 5s steps({{ strings.RuneCount .Site.Params.homeSubtitle }}, end),blink-caret .75s step-end infinite;
   }


### PR DESCRIPTION
I saw that the margin-bottom is not the same as the image in Readme when homeSubtitlePrinter is set to true so look in the code for a bit.

I found that https://github.com/1bl4z3r/hermit-V2/blob/4fcea430cfbeaa40d8b5aa2a1886a344c8a609a2/assets/scss/style.scss#L406 is override by https://github.com/1bl4z3r/hermit-V2/blob/4fcea430cfbeaa40d8b5aa2a1886a344c8a609a2/assets/scss/style.scss#L917 when you add homeSubtitlePrinter in #2 