### PR TITLE
Fix context given to customs_css

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,3 +1,5 @@
+{{ $rootCtx := . }}
+
 <!DOCTYPE html>
 <html lang="{{.Site.LanguageCode}}">
 <head>
@@ -14,7 +16,7 @@
 {{ $style := resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "css/style.css" . | toCSS | minify | fingerprint -}}
 <link rel="stylesheet dns-prefetch preconnect preload prefetch" as="style" href="{{ $style.Permalink }}" {{ printf "integrity=%q" $style.Data.Integrity | safeHTMLAttr }} crossorigin="anonymous">
 {{- range .Params.custom_css -}}
-{{ $c_css := resources.Get . | resources.ExecuteAsTemplate "css/style.css" . | toCSS | minify | fingerprint -}}
+{{ $c_css := resources.Get . | resources.ExecuteAsTemplate "css/style.css" $rootCtx | toCSS | minify | fingerprint -}}
 <link rel="stylesheet preload prefetch" as="style" href="{{ $c_css.Permalink }}" {{ printf "integrity=%q" $c_css.Data.Integrity | safeHTMLAttr }} crossorigin="anonymous">
 {{- end -}}
 {{- block "head" . -}}{{- end -}}


### PR DESCRIPTION
Due to scoping thing, we were passing down a string rather than the full context.