### PR TITLE
Fix default `pre code background color`.

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -60,7 +60,7 @@ pre {
   code {
     padding: 0;
     margin: 0;
-    background: #272822;
+    background: $midnightblue;
   }
 }
 


### PR DESCRIPTION
Fix default strange color:
![8449802c-1b75-4d89-84db-7c10f9e028b4](https://github.com/1bl4z3r/hermit-V2/assets/679757/1d6e6adc-3e11-48b5-93ab-a41ad295d521)
to:
![image](https://github.com/1bl4z3r/hermit-V2/assets/679757/27999b5c-cbf4-41f0-bed7-a73b7d967c06)
