### PR TITLE
Print the page description in RSS feed

### DIFF
--- a/layouts/posts/rss.xml
+++ b/layouts/posts/rss.xml
@@ -19,7 +19,7 @@
 			<pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
 			{{ with .Site.Params.author.email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
 			<guid>{{ .Permalink }}</guid>
-			<description>{{ .Summary | html }}</description>
+			<description>{{ printf `<![CDATA[%s]]>` .Page.Params.description | safeHTML }}</description>
 			<content type="html">{{ printf `<![CDATA[%s]]>` .Content | safeHTML }}</content>
 		</item>
 		{{ end }}


### PR DESCRIPTION
The RSS feed used to print the first chars of the page in the "description" field. Since there is a description at the page level, it's now displayed instead.
It should provide a cleaner and complete description.