### PR TITLE
Correct the link to favicon

### DIFF
--- a/layouts/partials/site-meta.html
+++ b/layouts/partials/site-meta.html
@@ -7,10 +7,10 @@
 <link rel="author" href="{{"humans.txt" | relURL}}">
 <link rel="apple-touch-icon" sizes="180x180" href="{{"apple-touch-icon.png" | relURL}}">
 {{- if (fileExists "static/favicon.ico") -}}
-<link rel="icon" href="{{"favicon.ico" | relURL}}" type="image/x-icon" sizes="any">
+<link rel="icon" href="{{"favicon.ico" | relURL}}" sizes="48x48">
 {{- end -}}
 {{- if (fileExists "static/favicon.svg") -}}
-<link rel="icon" href="{{"favicon.svg" | relURL}}" type="image/svg+xml">
+<link rel="icon" href="{{"favicon.svg" | relURL}}" type="image/svg+xml" sizes="any">
 {{- end -}}
 <link rel="icon" type="image/png" sizes="32x32" href="{{"favicon-32x32.png" | relURL}}">
 <link rel="icon" type="image/png" sizes="16x16" href="{{"favicon-16x16.png" | relURL}}">


### PR DESCRIPTION
Chrome behavior has changed since 2023, following https: //medium.com/web-dev-survey-from-kyoto/favicon-nightmare-how-to-maintain-sanity-7628bfc39918 .

Tested on both Chrome and Firefox.

Fix #60