### PR TITLE
feat: add option to toggle footer theme name display

### DIFF
--- a/hugo.toml.example
+++ b/hugo.toml.example
@@ -90,6 +90,8 @@ expiryDate = ["expiryDate"]
 
   #homeSubtitle = "CHANGE ME HOME SUBTITLE"
   footerCopyright = "CHANGE ME FOOTER COPYRIGHT"
+  # Whether to show a tribute to hugo and hermit-v2 theme
+  footerThemeName = true
   # bgImg = ""
   # gitUrl = "https://github.com/1bl4z3r/hermit-V2/tree/staging"
 

--- a/hugo.toml.example
+++ b/hugo.toml.example
@@ -91,7 +91,7 @@ expiryDate = ["expiryDate"]
   #homeSubtitle = "CHANGE ME HOME SUBTITLE"
   footerCopyright = "CHANGE ME FOOTER COPYRIGHT"
   # Whether to show a tribute to hugo and hermit-v2 theme
-  footerThemeName = true
+  footerHideThemeName = false
   # bgImg = ""
   # gitUrl = "https://github.com/1bl4z3r/hermit-V2/tree/staging"
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,8 +2,10 @@
 	<p>
 		&copy; {{ now.Format "2006" }} <a href="{{ .Site.BaseURL }}">{{ .Site.Params.author.name }}</a>
 		&#183; {{ .Site.Params.footerCopyright | safeHTML }}
-		&#183; Made with <a href="https://gohugo.io/" target="_blank" rel="noopener">Hugo</a>
-		&#183; Theme <a href="https://github.com/1bl4z3r/hermit-V2" target="_blank" rel="noopener">Hermit-V2</a>
+		{{- if .Site.Params.footerThemeName -}}
+			&#183; Made with <a href="https://gohugo.io/" target="_blank" rel="noopener">Hugo</a>
+			&#183; Theme <a href="https://github.com/1bl4z3r/hermit-V2" target="_blank" rel="noopener">Hermit-V2</a>
+		{{- end -}}
 		{{- with .OutputFormats.Get "RSS" }}
 		&#183; <a href="{{ "posts/index.xml" | absLangURL }}" target="_blank" title="rss">{{- partial "svg.html" (dict "context" . "name" "rss") -}}</a>
 		{{- end -}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
 	<p>
 		&copy; {{ now.Format "2006" }} <a href="{{ .Site.BaseURL }}">{{ .Site.Params.author.name }}</a>
 		&#183; {{ .Site.Params.footerCopyright | safeHTML }}
-		{{- if .Site.Params.footerThemeName -}}
+		{{- if not .Site.Params.footerHideThemeName -}}
 			&#183; Made with <a href="https://gohugo.io/" target="_blank" rel="noopener">Hugo</a>
 			&#183; Theme <a href="https://github.com/1bl4z3r/hermit-V2" target="_blank" rel="noopener">Hermit-V2</a>
 		{{- end -}}


### PR DESCRIPTION
This PR:
 - Introduced `footerThemeName` parameter in `hugo.toml` to control the display of Hugo and Hermit-V2 theme tribute in the footer.
 - Updated `footer.html` to conditionally display the tribute based on the `footerThemeName` parameter.

Related issue:
- #28