### PR TITLE
add instructions to use relative path for img

### DIFF
--- a/content/posts/the-figure-shortcode.md
+++ b/content/posts/the-figure-shortcode.md
@@ -26,6 +26,7 @@ This theme extends upon default figure shortcode to implement following features
 * Convert WEBP Images on the fly to JPG and serve WEBP images with JPG as a fallback.
 * If `src` contains a link (starting with http/https), it will be parsed accordingly.
 * 1-to-1 feature set compatiblity if you are using figure shortcode or `![]()`.
+* To use relative paths images need to be put in a folder "assets" in the root of the folder. see [Hugo docs] for more details.
 
 Here's some examples, please be aware that these styles only take effect when the page width is over 1300px.
 
@@ -42,6 +43,10 @@ Suspendisse fringilla malesuada massa, in malesuada orci lacinia a. Praesent dap
 In a libero varius, luctus ligula et, bibendum tortor. Sed sit amet dui malesuada, mattis justo id, ultricies enim. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aliquam sollicitudin cursus feugiat. Vivamus suscipit ipsum eget lobortis sollicitudin. Fusce vehicula neque tellus. Integer eu posuere quam, id laoreet tortor. Mauris sit amet turpis urna. Donec venenatis tempor dolor, nec laoreet orci aliquet et. Sed condimentum elit eu tristique aliquam. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nunc luctus ipsum sit amet nisl maximus pellentesque.
 
 {{< figure src="https://placehold.co/400x280" alt="image" caption="figure-right" class="right" >}}
+
+Pellentesque eu consequat nunc. Vivamus eu eros ut nulla dapibus molestie in id tortor. Cras viverra ligula erat, tincidunt hendrerit diam blandit nec. Cras id urna vel dolor dictum mattis. Vestibulum congue erat ac eros molestie accumsan. Maecenas lorem nibh, maximus vel justo eget, facilisis egestas lectus. Mauris eu est ut odio blandit consequat id feugiat eros. Fusce id suscipit mi, et lacinia lectus. Mauris a arcu placerat dolor iaculis feugiat nec non mi. Ut porttitor elit tortor, eget tempus velit mollis eu. Aliquam sem nulla, dictum cursus mauris ac, semper ullamcorper leo.
+
+{{< figure src="images/928-600x400.jpg" alt="image" caption="relative file path" >}}
 
 Pellentesque eu consequat nunc. Vivamus eu eros ut nulla dapibus molestie in id tortor. Cras viverra ligula erat, tincidunt hendrerit diam blandit nec. Cras id urna vel dolor dictum mattis. Vestibulum congue erat ac eros molestie accumsan. Maecenas lorem nibh, maximus vel justo eget, facilisis egestas lectus. Mauris eu est ut odio blandit consequat id feugiat eros. Fusce id suscipit mi, et lacinia lectus. Mauris a arcu placerat dolor iaculis feugiat nec non mi. Ut porttitor elit tortor, eget tempus velit mollis eu. Aliquam sem nulla, dictum cursus mauris ac, semper ullamcorper leo.
 


### PR DESCRIPTION
This PR is to improve how relative file paths can be used to add image instead of web links. Since there are two folders `st
atic` and `assets`. It is worth mentioning static won't work which is what I wasted time doing and assets is what works because the figures shortcode uses uses Hugo pipes to try to find the files.