### PR TITLE
Renamed the Div home-social to home-links

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -290,7 +290,7 @@ table {
   font-size: 1.2em;
 }
 
-.hdr-social {
+.hdr-links {
   display: inline-block;
   margin-left: .6em;
 

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -431,7 +431,7 @@ p.img-404 {
   opacity: .9;
 }
 
-#home-social {
+#home-links {
   font-size: 1.4em;
   text-align: center;
   opacity: .8;

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -19,7 +19,7 @@
 			<p id="home-subtitle">{{.}}</p>
 			{{- end }}
 			{{- with .Site.Params.socialLinks }}
-			<div id="home-social">
+			<div id="home-links">
 				{{ partialCached "social-icons.html" . }}
 			</div>
 			{{- end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,7 +14,7 @@
 				<button id="toc-btn" class="hdr-btn desktop-only-ib" title="{{i18n "tableOfContents"}}">{{- partial "svg.html" (dict "context" . "name" "toc") -}}</button>
 				{{- end -}}
 				{{- with .Site.Params.socialLinks -}}
-				<span class="hdr-social hide-in-mobile">{{- partialCached "social-icons.html" . -}}</span>
+				<span class="hdr-links hide-in-mobile">{{- partialCached "social-icons.html" . -}}</span>
 				{{- end -}}
 				{{- if and (not (eq .Site.Params.shareSocial nil)) (.Site.Params.shareSocial) (templates.Exists "partials/social-share.html") -}}{{- partial "social-share.html" . -}}{{- end -}}
 				<button id="menu-btn" class="hdr-btn" title="{{i18n "menu"}}">{{- partial "svg.html" (dict "context" . "name" "menuBtn") -}}</button>


### PR DESCRIPTION
Since some [EasyList rules](https://easylist.to/easylist/fanboy-social.txt) can block the whole div, I think renaming it to something not including "social" would prevent breaking one of the main features of this template.