### PR TITLE
layouts: allows to set custom css used for alle sites

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,6 +17,10 @@
 {{ $c_css := resources.Get . | resources.ExecuteAsTemplate "css/style.css" $rootCtx | toCSS | minify | fingerprint -}}
 <link rel="stylesheet preload prefetch" as="style" href="{{ $c_css.Permalink }}" {{ printf "integrity=%q" $c_css.Data.Integrity | safeHTMLAttr }} crossorigin="anonymous">
 {{- end -}}
+{{- range .Site.Params.custom_css -}}
+{{ $c_css := resources.Get . | resources.ExecuteAsTemplate "css/style.css" $rootCtx | toCSS | minify | fingerprint -}}
+<link rel="stylesheet preload prefetch" as="style" href="{{ $c_css.Permalink }}" {{ printf "integrity=%q" $c_css.Data.Integrity | safeHTMLAttr }} crossorigin="anonymous">
+{{- end -}}
 {{- block "head" . -}}{{- end -}}
 {{- if templates.Exists "partials/extra-head.html" -}}{{- partial "extra-head.html" . -}}{{- end -}}
 </head>


### PR DESCRIPTION
I'd like to have an option to set a custom css of the whole page to add to the template for the whole page
(setting the opacity and some other parts)

However this was not respected before.

config.toml:
```
[params]
  # Add custom css in assets folder
  custom_css = ["css/custom.css"]
```

include custom css in `assets/css/custom.css`

There might be an easier way like:
https://discourse.gohugo.io/t/how-to-access-site-params-map-with-a-params-variable/348

Though I am not too familiar with this