### PR TITLE
fix spacing before word count

### DIFF
--- a/layouts/partials/posts_single_info.html
+++ b/layouts/partials/posts_single_info.html
@@ -12,7 +12,7 @@
 {{- with .Params.categories }}
 <p>{{- partial "svg.html" (dict "context" . "name" "posts_single_categories") -}}{{- range . -}}<span class="category"><a href="{{ "categories/" | absLangURL }}{{ . | urlize }}">{{.}}</a></span>{{- end }}</p>
 {{- end }}
-<p>{{- partial "svg.html" (dict "context" . "name" "posts_single_wordcount") }}{{- .WordCount }} {{- if fileExists "i18n" }} {{ i18n "wordCount" . -}} {{- else -}} Words {{- end }} {{ partial "readTime.html" . -}}</p>
+<p>{{- partial "svg.html" (dict "context" . "name" "posts_single_wordcount") }}{{- .WordCount }}&nbsp{{- if fileExists "i18n" }} {{ i18n "wordCount" . -}} {{- else -}} Words {{- end }} {{ partial "readTime.html" . -}}</p>
 <p>{{- partial "svg.html" (dict "context" . "name" "posts_single_date") }}{{ dateFormat .Site.Params.dateformNumTime .Date.Local }}
 {{ if .Page.Params.ShowLastmod -}}
 {{- if and .GitInfo .Site.Params.gitUrl -}}


### PR DESCRIPTION
The wordcount spacing was missing from the rendered template.
This is fixed by adding a nbsp as used elsewhere as well.