### PR TITLE
fix rss image relying on site.BaseURL

### DIFF
--- a/layouts/partials/rss-image.xml
+++ b/layouts/partials/rss-image.xml
@@ -9,7 +9,7 @@
 </media:content>
 {{- end -}}
 {{- else if findRE `^\/.*` $path 1 -}}
-{{ $path := printf "%s%s" .Site.BaseURL (strings.TrimLeft "/" $path) }}
+{{ $path := printf "%s%s" site.BaseURL (strings.TrimLeft "/" $path) }}
 			{{- with resources.GetRemote $path -}}
 			<enclosure url="{{ .Permalink }}" length="" type="{{ .MediaType }}" />
 			<media:thumbnail url="{{ .Permalink }}" width="{{ .Width}}" height="{{ .Height}}" />


### PR DESCRIPTION
On v0.131.0+extended I get the following error on the rss-image.xml template:

```
Error: error building site: render: failed to render pages: render of "home" failed: "blog/themes/hermit-v2/layouts/rss.xml:47:7": 
execute of template failed: template: rss.xml:47:7: executing "rss.xml" at <partial "rss-image.xml" (dict "path" .)>:
error calling partial: "blog/themes/hermit-v2/layouts/partials/rss-image.xml:12:32":
execute of template failed: template: partials/rss-image.xml:12:32: executing "partials/rss-image.xml" at <.Site.BaseURL>:
can't evaluate field Site in type string
```

The .Site is executed on the path property of the image (which is of type string) and does not have a Site key.

This is fixed by using the global `site.BaseURL` as used in other partials to overcome this