### PR TITLE
Fix: Only load gallery.js when gallery shortcode is used

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -50,10 +50,12 @@
 {{- partial "mathjax.html" . -}}
 {{- partial "mermaid.html" . -}}
 {{- if templates.Exists "partials/extra-foot.html" -}}{{- partial "extra-foot.html" . -}}{{- end }}
-{{ $galleryJS := resources.Get "js/gallery.js" }}
-{{ if $galleryJS }}
-	{{ $galleryJS = $galleryJS | minify | fingerprint }}
-  	<script defer src="{{ $galleryJS.RelPermalink }}" {{ printf "integrity=%q" $galleryJS.Data.Integrity | safeHTMLAttr }} crossorigin="anonymous"></script>
+{{ if .HasShortcode "gallery" }}
+  {{ $galleryJS := resources.Get "js/gallery.js" }}
+  {{ if $galleryJS }}
+    {{ $galleryJS = $galleryJS | minify | fingerprint }}
+    <script defer src="{{ $galleryJS.RelPermalink }}" {{ printf "integrity=%q" $galleryJS.Data.Integrity | safeHTMLAttr }} crossorigin="anonymous"></script>
+  {{ end }}
 {{ end }}
 
 </body>


### PR DESCRIPTION
This fix prevents the gallery.js file from being loaded on pages that don't use the gallery shortcode. 
Previously, the gallery.js file was loaded on every page, causing the lightbox HTML elements to be 
created and appended to the body of every page, even on pages where no gallery was present.

This resulted in "Lightbox image" alt text and navigation buttons appearing at the bottom of pages 
that didn't use the gallery feature.

This bug was introduced in commit 9bfd89a ("New: Gallery for images (Initial commit)").

The fix makes use of the Hugo feature `hasshortcode` https://gohugo.io/methods/page/hasshortcode/