### PR TITLE
feat/fix: typewriter animation moved to JS from CSS

### DIFF
--- a/assets/js/typewriter.js
+++ b/assets/js/typewriter.js
@@ -1,0 +1,29 @@
+document.addEventListener("DOMContentLoaded", function () {
+    const el = document.getElementById("home-subtitle");
+    if (!el) return;
+  
+    const fullText = el.dataset.fulltext || el.textContent.trim(); // fallback if not using data attr
+    const speed = 75; // typing speed in ms
+    let index = 0;
+  
+    el.textContent = ""; // Clear any existing text
+  
+    // Create and style the blinking caret
+    const caret = document.createElement("span");
+    caret.textContent = "|";
+    caret.style.animation = "blink 0.7s step-end infinite";
+    el.appendChild(caret);
+  
+    function typeWriter() {
+      if (index < fullText.length) {
+        el.insertBefore(document.createTextNode(fullText.charAt(index)), caret);
+        index++;
+        setTimeout(typeWriter, speed);
+      } else {
+        // Optionally remove the caret at the end
+        // caret.remove();
+      }
+    }
+  
+    typeWriter();
+  });

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -474,13 +474,20 @@ p.img-404 {
 }
 
 #home-subtitle {
-  margin-top: 0;
-  margin-bottom: 1.5em;
+  margin: 0 auto 1.5em auto;
   text-align: center;
   line-height: normal;
-  font-size: .7em;
+  font-size: 0.7em;
   font-style: italic;
-  opacity: .9;
+  opacity: 0.9;
+  white-space: normal; // Let the text wrap on all screens
+  overflow: hidden;
+}
+
+@media (max-width: 520px) {
+  #home-subtitle {
+    font-size: 0.5em;
+  }
 }
 
 #home-links {
@@ -1102,17 +1109,6 @@ a.footnote-ref {
   justify-content: flex-end;
 }
 
-// If homeSubtitlePrinter is true
-{{- if .Site.Params.homeSubtitlePrinter }}
-  #home-subtitle{
-    overflow: hidden; /* Ensures the content is not revealed until the animation */
-    border-right: .5em solid $typewriter; /* The typwriter cursor */
-    white-space: nowrap; /* Keeps the content on a single line */
-    margin: 0 auto 1.5em auto; /* Gives that scrolling effect as the typing happens */
-    // letter-spacing: .100em; /* Adjust as needed */
-    animation: typing 5s steps({{ strings.RuneCount .Site.Params.homeSubtitle }}, end),blink-caret .75s linear 5.1s infinite;
-  }
-
   /* The typing effect */
   @keyframes typing {
     from {max-width: 0;}
@@ -1124,7 +1120,12 @@ a.footnote-ref {
     from, to { border-color: transparent }
     50% { border-color: $typewriter}
   }
-{{ end -}}
+
+  @keyframes blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0; }
+  }
+
 {{- if (fileExists "assets/scss/userstyles.scss") }}
 @import "userstyles.scss";
 {{ end -}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -47,6 +47,12 @@
 	{{ $c_js := resources.Get . | minify | fingerprint -}}
 	<script defer src="{{ $c_js.Permalink }}" {{ printf "integrity=%q" $c_js.Data.Integrity | safeHTMLAttr }} crossorigin="anonymous"></script>
 	{{- end }}
+	{{- if .Site.Params.homeSubtitlePrinter | default true -}}
+  	{{- $typewriter := resources.Get "js/typewriter.js" | minify | fingerprint -}}
+  	<script defer src="{{ $typewriter.RelPermalink }}" integrity="{{ $typewriter.Data.Integrity }}" crossorigin="anonymous"></script>
+	{{- else -}}
+  	<!-- Typewriter disabled: fallback or nothing -->
+	{{- end -}}
 	{{- partial "mathjax.html" . -}}
 	{{- partial "mermaid.html" . -}}
 	{{- if templates.Exists "partials/extra-foot.html" -}}{{- partial "extra-foot.html" . -}}{{- end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -15,9 +15,10 @@
 	<div id="spotlight" {{- if ne false .Site.Params.usesAnimation }} class="animated fadeIn" {{- end -}}>
 		<div id="home-center">
 			<h1 id="home-title">{{ .Site.Title }}</h1>
-			{{- with .Site.Params.homeSubtitle }}
-			<p id="home-subtitle">{{.}}</p>
-			{{- end }}
+			{{ $subtitle := .Site.Params.homeSubtitle }}
+			{{ if $subtitle }}
+			<p id="home-subtitle" data-fulltext="{{ $subtitle }}">{{ $subtitle }}</p>
+			{{ end }}
 			{{- with .Site.Params.socialLinks }}
 			<div id="home-links">
 				{{ partialCached "social-icons.html" . }}


### PR DESCRIPTION
When your home subtitle is longer than 55 characters, on smaller viewports (mobile),  the text runs off-screen. To allow for more optimized wrapping of this text on mobile, the typewriter was rewritten in JS, and all existing params remain functional as before.

https://github.com/user-attachments/assets/f778f93a-bae0-4645-a50b-dcba9ba93b3a

