### PR TITLE
fix: replace deprecated .Site.LanguageCode with .Site.Language.Locale

### DIFF
--- a/hugo.toml.example
+++ b/hugo.toml.example
@@ -27,7 +27,7 @@ defaultContentLanguageInSubdir = true
 #      homeSubtitle = "CHANGE ME"
 #    weight = 3
  
-languageCode = "en-us"
+locale = "en-US"
 
 # title = "CHANGE ME"
 # enableGitInfo = true

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,6 +1,6 @@
 {{- $rootCtx := . -}}
 <!DOCTYPE html>
-<html lang="{{.Site.LanguageCode}}">
+<html lang="{{.Site.Language.Locale}}">
 
 <head>
 	{{- partial "google-tag-manager.html" (dict "context" . "name" "head") -}}

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -16,7 +16,7 @@
 		<title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
 		<link>{{ .Permalink }}</link>
 		<description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-		<generator>Hugo -- {{ hugo.Version }}</generator>{{ with .Site.LanguageCode }}
+		<generator>Hugo -- {{ hugo.Version }}</generator>{{ with .Site.Language.Locale }}
 		<language>{{.}}</language>{{end}}{{ with .Site.Params.author.email }}
 		<managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.author.email }}
 		<webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}


### PR DESCRIPTION
.Site.LanguageCode was deprecated in Hugo v0.158.0 and will be removed in a future release. Hugo now emits a WARN on every build:

  deprecated: .Site.LanguageCode was deprecated in Hugo v0.158.0 and
  will be removed in a future release. Use .Site.Language.Locale instead.

Replace all occurrences with .Site.Language.Locale:
- layouts/baseof.html (html[lang] attribute)
- layouts/rss.xml (<language> element)