### PR TITLE
Fix the text before the last modification date

### DIFF
--- a/layouts/_partials/posts_single_info.html
+++ b/layouts/_partials/posts_single_info.html
@@ -18,7 +18,7 @@
 {{- if and .GitInfo .Site.Params.gitUrl -}}
 [{{- partial "svg.html" (dict "context" . "name" "posts_single_git_commit") -}}<a href="{{ .Site.Params.gitUrl -}}{{ .GitInfo.Hash }}" target="_blank" rel="noopener">{{ .GitInfo.AbbreviatedHash -}}</a> @ {{ dateFormat (default "2006-01-02" .Site.Params.dateform.NumDateShort) .GitInfo.AuthorDate.Local -}}]
 {{- else if not (eq .Lastmod .Date ) -}}
-[{{ .Site.Params.initialPublish | default "Initially Published on : " }} {{ dateFormat (default "2006-01-02 15:04 -0700" .Site.Params.dateform.NumDateLong) .Lastmod.Local -}}]
+[{{ .Site.Params.lastUpdatedOn | default "Last updated on: " }} {{ dateFormat (default "2006-01-02 15:04 -0700" .Site.Params.dateform.NumDateLong) .Lastmod.Local -}}]
 {{- else -}}
 {{ errorf "Lastmod is not found in Page Frontmatter or Lastmod is same as Date in %s" .Permalink }}
 {{- end -}}


### PR DESCRIPTION
When "showlastmod" is true and "lastmod" is set, the text "Initially Published on : {lastmod}" is displayed next to the publication date, with {lastmod} being the date set in "lastmod". This way, the publication date and last modification date are reversed.

Now the text is "Last updated on: {lastmod}" by default. To keep it clear, the parameter to configure this text is "lastUpdatedOn" instead of "initialPublish".